### PR TITLE
[android/CHIPTool] Add missing parts for rendezvous over BLE

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
@@ -49,7 +49,7 @@ class BluetoothManager {
                 val scanFilter = ScanFilter.Builder()
                     .setServiceData(
                       ParcelUuid(UUID.fromString(CHIP_UUID)),
-                      discriminator.toByteArray(3)
+                      byteArrayOf(0, discriminator.toByte(), (discriminator shr 8).toByte())
                     )
                     .build()
                 val scanSettings = ScanSettings.Builder()
@@ -93,14 +93,9 @@ class BluetoothManager {
             }
 
             Log.i(TAG, "Connecting")
-            val gatt = device.connectGatt(context, false, bluetoothGattCallback)
+            val gatt = device.connectGatt(context, false, bluetoothGattCallback, BluetoothDevice.TRANSPORT_LE)
             continuation.invokeOnCancellation { gatt.disconnect() }
         }
-    }
-
-    /** Converts an integer to a ByteArray with the first [size] bytes of the [Int]. */
-    private fun Int.toByteArray(size: Int): ByteArray {
-        return ByteArray(size) { i -> (this shr (8 * i)).toByte() }
     }
 
     companion object {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
@@ -14,6 +14,7 @@ import android.bluetooth.le.ScanSettings
 import android.content.Context
 import android.os.ParcelUuid
 import android.util.Log
+import chip.devicecontroller.AndroidChipStack
 import chip.devicecontroller.ChipDeviceController
 import java.util.UUID
 import kotlin.coroutines.resume
@@ -69,9 +70,9 @@ class BluetoothManager {
     /**
      * Connects to a [BluetoothDevice] and suspends until [BluetoothGattCallback.onServicesDiscovered]
      */
-    suspend fun connect(context: Context, device: BluetoothDevice, controller: ChipDeviceController): BluetoothGatt? {
+    suspend fun connect(context: Context, device: BluetoothDevice): BluetoothGatt? {
         return suspendCancellableCoroutine { continuation ->
-            val bluetoothGattCallback = object : BluetoothGattCallback() {
+            val bluetoothGattCallback = object : AndroidChipStack.ChipGattCallback() {
                 override fun onConnectionStateChange(
                   gatt: BluetoothGatt?,
                   status: Int,
@@ -92,24 +93,6 @@ class BluetoothManager {
                     if (continuation.isActive) {
                         continuation.resume(gatt)
                     }
-                }
-
-                override fun onCharacteristicWrite(gatt: BluetoothGatt?, characteristic: BluetoothGattCharacteristic, status: Int) {
-                    super.onCharacteristicWrite(gatt, characteristic, status)
-                    Log.i("$TAG|onCharacteristicWrite", "ACK received")
-                    controller.onCharacteristicWrite(gatt, characteristic.uuid.toString(), status)
-                }
-
-                override fun onDescriptorWrite(gatt: BluetoothGatt?, desc: BluetoothGattDescriptor, status: Int) {
-                    super.onDescriptorWrite(gatt, desc, status)
-                    Log.i("$TAG|onDescriptorWrite", if (desc.value == BluetoothGattDescriptor.ENABLE_INDICATION_VALUE) "Subscribed" else "Unsubscribed")
-                    controller.onDescriptorWrite(gatt, desc.characteristic.uuid.toString(), desc.value, status)
-                }
-
-                override fun onCharacteristicChanged(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic) {
-                    super.onCharacteristicChanged(gatt, characteristic)
-                    Log.i("$TAG|onCharacteristicChanged", "Indication Received")
-                    controller.onCharacteristicChanged(gatt, characteristic.uuid.toString(), characteristic.value)
                 }
             }
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
@@ -97,7 +97,7 @@ class CHIPDeviceDetailsFragment : Fragment(), ChipDeviceController.CompletionLis
                     return@launch
                 }
 
-                gatt = bluetoothManager.connect(requireContext(), device, deviceController)
+                gatt = bluetoothManager.connect(requireContext(), device)
                 deviceController.setCompletionListener(this@CHIPDeviceDetailsFragment)
                 deviceController.beginConnectDeviceBle(gatt, deviceInfo.setupPinCode);
             }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
@@ -27,6 +27,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import chip.devicecontroller.ChipDeviceController
+import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.R
 import com.google.chip.chiptool.bluetooth.BluetoothManager
 import kotlinx.android.synthetic.main.chip_device_info_fragment.view.*
@@ -89,19 +90,22 @@ class CHIPDeviceDetailsFragment : Fragment(), ChipDeviceController.CompletionLis
     private fun onRendezvousBleClicked() {
         if (gatt == null) {
             scope.launch {
+                val deviceController = ChipClient.getDeviceController()
                 val bluetoothManager = BluetoothManager()
                 val device = bluetoothManager.getBluetoothDevice(deviceInfo.discriminator) ?: run {
                     Log.i(TAG, "No device found")
                     return@launch
                 }
 
-                gatt = bluetoothManager.connect(requireContext(), device)
+                gatt = bluetoothManager.connect(requireContext(), device, deviceController)
+                deviceController.setCompletionListener(this@CHIPDeviceDetailsFragment)
+                deviceController.beginConnectDeviceBle(gatt, deviceInfo.setupPinCode);
             }
         }
     }
 
     override fun onConnectDeviceComplete() {
-        Log.d(TAG, "TODO: Retrieve Wi-Fi credentials and send to device.")
+        Log.d(TAG, "TODO: Retrieve Wi-Fi/Thread credentials and send to device.")
     }
 
     override fun onCloseBleComplete() {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -190,11 +190,9 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, Rendezvous
     }
 #endif // CONFIG_DEVICE_LAYER
 
-    rendezvousSession = new RendezvousSession(this);
-    err               = rendezvousSession->Init(params.SetLocalNodeId(mLocalDeviceId));
+    mRendezvousSession = new RendezvousSession(this);
+    err                = mRendezvousSession->Init(params.SetLocalNodeId(mLocalDeviceId));
     SuccessOrExit(err);
-
-    mRendezvousSession = rendezvousSession;
 
     mRemoteDeviceId  = Optional<NodeId>::Value(remoteDeviceId);
     mDevicePort      = devicePort;
@@ -209,9 +207,10 @@ CHIP_ERROR ChipDeviceController::ConnectDevice(NodeId remoteDeviceId, Rendezvous
     mOnError             = onError;
 
 exit:
-    if (err != CHIP_NO_ERROR && rendezvousSession != nullptr)
+    if (err != CHIP_NO_ERROR && mRendezvousSession != nullptr)
     {
-        delete rendezvousSession;
+        delete mRendezvousSession;
+        mRendezvousSession = nullptr;
     }
 
     return err;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -410,56 +410,100 @@ JNI_METHOD(void, beginSendCommand)(JNIEnv * env, jobject self, jlong deviceContr
     }
 }
 
-JNI_METHOD(void, handleIndicationReceived)(JNIEnv * env, jobject self, jint conn, jstring charId, jbyteArray value)
+static bool JavaBytesToUUID(JNIEnv * env, jbyteArray value, chip::Ble::ChipBleUUID & uuid)
+{
+    const auto valueBegin  = env->GetByteArrayElements(value, nullptr);
+    const auto valueLength = env->GetArrayLength(value);
+    bool result            = true;
+
+    VerifyOrExit(valueBegin && valueLength == sizeof(uuid.bytes), result = false);
+    memcpy(uuid.bytes, valueBegin, valueLength);
+
+exit:
+    env->ReleaseByteArrayElements(value, valueBegin, 0);
+    return result;
+}
+
+JNI_METHOD(void, handleIndicationReceived)(JNIEnv * env, jobject self, jint conn, jbyteArray svcId, jbyteArray charId, jbyteArray value)
 {
     BLE_CONNECTION_OBJECT const connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(conn);
-    const char * const charIdStr        = env->GetStringUTFChars(charId, 0);
     const auto valueBegin               = env->GetByteArrayElements(value, nullptr);
     const auto valueLength              = env->GetArrayLength(value);
-    chip::Ble::ChipBleUUID uuid;
 
-    const auto buffer = System::PacketBuffer::NewWithAvailableSize(valueLength);
-    VerifyOrExit(buffer != nullptr, ChipLogError(Controller, "Failed to allocate packet buffer"));
+    chip::Ble::ChipBleUUID svcUUID;
+    chip::Ble::ChipBleUUID charUUID;
+    chip::System::PacketBuffer* buffer = nullptr;
+
+    VerifyOrExit(JavaBytesToUUID(env, svcId, svcUUID),
+                 ChipLogError(Controller, "handleIndicationReceived() called with invalid service ID"));
+    VerifyOrExit(JavaBytesToUUID(env, charId, charUUID),
+                 ChipLogError(Controller, "handleIndicationReceived() called with invalid characteristic ID"));
+
+    buffer = System::PacketBuffer::NewWithAvailableSize(valueLength);
+    VerifyOrExit(buffer, ChipLogError(Controller, "Failed to allocate packet buffer"));
 
     memcpy(buffer->Start(), valueBegin, valueLength);
     buffer->SetDataLength(valueLength);
 
-    VerifyOrExit(chip::Ble::StringToUUID(charIdStr, uuid), ChipLogError(Controller, "Invalid characteristic ID: %s", charIdStr));
-
-    sBleLayer.HandleIndicationReceived(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &uuid, buffer);
-
+    sBleLayer.HandleIndicationReceived(connObj, &svcUUID, &charUUID, buffer);
 exit:
     env->ReleaseByteArrayElements(value, valueBegin, 0);
-    env->ReleaseStringUTFChars(charId, charIdStr);
 }
 
-JNI_METHOD(void, handleWriteConfirmation)(JNIEnv * env, jobject self, jint conn, jstring charId)
+JNI_METHOD(void, handleWriteConfirmation)(JNIEnv * env, jobject self, jint conn, jbyteArray svcId, jbyteArray charId)
 {
     BLE_CONNECTION_OBJECT const connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(conn);
-    const char * const charIdStr        = env->GetStringUTFChars(charId, 0);
 
-    chip::Ble::ChipBleUUID uuid;
-    VerifyOrExit(chip::Ble::StringToUUID(charIdStr, uuid), ChipLogError(Controller, "Invalid characteristic ID: %s", charIdStr));
-
-    sBleLayer.HandleWriteConfirmation(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &uuid);
-
+    chip::Ble::ChipBleUUID svcUUID;
+    chip::Ble::ChipBleUUID charUUID;
+    VerifyOrExit(JavaBytesToUUID(env, svcId, svcUUID),
+                 ChipLogError(Controller, "handleWriteConfirmation() called with invalid service ID"));
+    VerifyOrExit(JavaBytesToUUID(env, charId, charUUID),
+                 ChipLogError(Controller, "handleWriteConfirmation() called with invalid characteristic ID"));
+                 
+    sBleLayer.HandleWriteConfirmation(connObj, &svcUUID, &charUUID);
 exit:
-    env->ReleaseStringUTFChars(charId, charIdStr);
+    return;
 }
 
-JNI_METHOD(void, handleSubscribeComplete)(JNIEnv * env, jobject self, jint conn, jstring charId)
+JNI_METHOD(void, handleSubscribeComplete)(JNIEnv * env, jobject self, jint conn, jbyteArray svcId, jbyteArray charId)
 {
     BLE_CONNECTION_OBJECT const connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(conn);
-    const char * const charIdStr        = env->GetStringUTFChars(charId, 0);
 
-    chip::Ble::ChipBleUUID uuid;
-    VerifyOrExit(chip::Ble::StringToUUID(charIdStr, uuid), ChipLogError(Controller, "Invalid characteristic ID: %s", charIdStr));
+    chip::Ble::ChipBleUUID svcUUID;
+    chip::Ble::ChipBleUUID charUUID;
+    VerifyOrExit(JavaBytesToUUID(env, svcId, svcUUID),
+                 ChipLogError(Controller, "handleSubscribeComplete() called with invalid service ID"));
+    VerifyOrExit(JavaBytesToUUID(env, charId, charUUID),
+                 ChipLogError(Controller, "handleSubscribeComplete() called with invalid characteristic ID"));
 
-    sBleLayer.HandleSubscribeComplete(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &uuid);
-
+    sBleLayer.HandleSubscribeComplete(connObj, &svcUUID, &charUUID);
 exit:
-    env->ReleaseStringUTFChars(charId, charIdStr);
+    return;
 }
+
+JNI_METHOD(void, handleUnsubscribeComplete)(JNIEnv * env, jobject self, jint conn, jbyteArray svcId, jbyteArray charId)
+{
+    BLE_CONNECTION_OBJECT const connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(conn);
+
+    chip::Ble::ChipBleUUID svcUUID;
+    chip::Ble::ChipBleUUID charUUID;
+    VerifyOrExit(JavaBytesToUUID(env, svcId, svcUUID),
+                 ChipLogError(Controller, "handleUnsubscribeComplete() called with invalid service ID"));
+    VerifyOrExit(JavaBytesToUUID(env, charId, charUUID),
+                 ChipLogError(Controller, "handleUnsubscribeComplete() called with invalid characteristic ID"));
+
+    sBleLayer.HandleUnsubscribeComplete(connObj, &svcUUID, &charUUID);
+exit:
+    return;
+}
+
+JNI_METHOD(void, handleConnectionError)(JNIEnv * env, jobject self, jint conn)
+{
+    BLE_CONNECTION_OBJECT const connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(conn);
+    sBleLayer.HandleConnectionError(connObj, BLE_ERROR_APP_CLOSED_CONNECTION);
+}
+
 
 JNI_METHOD(jboolean, isConnected)(JNIEnv * env, jobject self, jlong deviceControllerPtr)
 {

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -622,7 +622,6 @@ void HandleKeyExchange(ChipDeviceController * deviceController, Transport::PeerC
     HandleSimpleOperationComplete(deviceController, "ConnectDevice");
 }
 
-
 void HandleEchoResponse(ChipDeviceController * deviceController, void * appReqState, System::PacketBuffer * payload)
 {
     StackUnlockGuard unlockGuard;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -446,7 +446,9 @@ JNI_METHOD(void, handleIndicationReceived)
     memcpy(buffer->Start(), valueBegin, valueLength);
     buffer->SetDataLength(valueLength);
 
+    pthread_mutex_lock(&sStackLock);
     sBleLayer.HandleIndicationReceived(connObj, &svcUUID, &charUUID, buffer);
+    pthread_mutex_unlock(&sStackLock);
 exit:
     env->ReleaseByteArrayElements(value, valueBegin, 0);
 }
@@ -462,7 +464,9 @@ JNI_METHOD(void, handleWriteConfirmation)(JNIEnv * env, jobject self, jint conn,
     VerifyOrExit(JavaBytesToUUID(env, charId, charUUID),
                  ChipLogError(Controller, "handleWriteConfirmation() called with invalid characteristic ID"));
 
+    pthread_mutex_lock(&sStackLock);
     sBleLayer.HandleWriteConfirmation(connObj, &svcUUID, &charUUID);
+    pthread_mutex_unlock(&sStackLock);
 exit:
     return;
 }
@@ -478,7 +482,9 @@ JNI_METHOD(void, handleSubscribeComplete)(JNIEnv * env, jobject self, jint conn,
     VerifyOrExit(JavaBytesToUUID(env, charId, charUUID),
                  ChipLogError(Controller, "handleSubscribeComplete() called with invalid characteristic ID"));
 
+    pthread_mutex_lock(&sStackLock);
     sBleLayer.HandleSubscribeComplete(connObj, &svcUUID, &charUUID);
+    pthread_mutex_unlock(&sStackLock);
 exit:
     return;
 }
@@ -494,7 +500,9 @@ JNI_METHOD(void, handleUnsubscribeComplete)(JNIEnv * env, jobject self, jint con
     VerifyOrExit(JavaBytesToUUID(env, charId, charUUID),
                  ChipLogError(Controller, "handleUnsubscribeComplete() called with invalid characteristic ID"));
 
+    pthread_mutex_lock(&sStackLock);
     sBleLayer.HandleUnsubscribeComplete(connObj, &svcUUID, &charUUID);
+    pthread_mutex_unlock(&sStackLock);
 exit:
     return;
 }
@@ -502,7 +510,10 @@ exit:
 JNI_METHOD(void, handleConnectionError)(JNIEnv * env, jobject self, jint conn)
 {
     BLE_CONNECTION_OBJECT const connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(conn);
+
+    pthread_mutex_lock(&sStackLock);
     sBleLayer.HandleConnectionError(connObj, BLE_ERROR_APP_CLOSED_CONNECTION);
+    pthread_mutex_unlock(&sStackLock);
 }
 
 JNI_METHOD(jboolean, isConnected)(JNIEnv * env, jobject self, jlong deviceControllerPtr)

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -26,6 +26,7 @@
 #include "AndroidBleConnectionDelegate.h"
 #include "AndroidBlePlatformDelegate.h"
 
+#include <ble/BleUUID.h>
 #include <controller/CHIPDeviceController.h>
 #include <jni.h>
 #include <pthread.h>
@@ -407,6 +408,57 @@ JNI_METHOD(void, beginSendCommand)(JNIEnv * env, jobject self, jlong deviceContr
         ChipLogError(Controller, "Failed to send CHIP command.");
         ThrowError(env, err);
     }
+}
+
+JNI_METHOD(void, handleIndicationReceived)(JNIEnv * env, jobject self, jint conn, jstring charId, jbyteArray value)
+{
+    BLE_CONNECTION_OBJECT const connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(conn);
+    const char * const charIdStr        = env->GetStringUTFChars(charId, 0);
+    const auto valueBegin               = env->GetByteArrayElements(value, nullptr);
+    const auto valueLength              = env->GetArrayLength(value);
+    chip::Ble::ChipBleUUID uuid;
+
+    const auto buffer = System::PacketBuffer::NewWithAvailableSize(valueLength);
+    VerifyOrExit(buffer != nullptr, ChipLogError(Controller, "Failed to allocate packet buffer"));
+
+    memcpy(buffer->Start(), valueBegin, valueLength);
+    buffer->SetDataLength(valueLength);
+
+    VerifyOrExit(chip::Ble::StringToUUID(charIdStr, uuid), ChipLogError(Controller, "Invalid characteristic ID: %s", charIdStr));
+
+    sBleLayer.HandleIndicationReceived(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &uuid, buffer);
+
+exit:
+    env->ReleaseByteArrayElements(value, valueBegin, 0);
+    env->ReleaseStringUTFChars(charId, charIdStr);
+}
+
+JNI_METHOD(void, handleWriteConfirmation)(JNIEnv * env, jobject self, jint conn, jstring charId)
+{
+    BLE_CONNECTION_OBJECT const connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(conn);
+    const char * const charIdStr        = env->GetStringUTFChars(charId, 0);
+
+    chip::Ble::ChipBleUUID uuid;
+    VerifyOrExit(chip::Ble::StringToUUID(charIdStr, uuid), ChipLogError(Controller, "Invalid characteristic ID: %s", charIdStr));
+
+    sBleLayer.HandleWriteConfirmation(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &uuid);
+
+exit:
+    env->ReleaseStringUTFChars(charId, charIdStr);
+}
+
+JNI_METHOD(void, handleSubscribeComplete)(JNIEnv * env, jobject self, jint conn, jstring charId)
+{
+    BLE_CONNECTION_OBJECT const connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(conn);
+    const char * const charIdStr        = env->GetStringUTFChars(charId, 0);
+
+    chip::Ble::ChipBleUUID uuid;
+    VerifyOrExit(chip::Ble::StringToUUID(charIdStr, uuid), ChipLogError(Controller, "Invalid characteristic ID: %s", charIdStr));
+
+    sBleLayer.HandleSubscribeComplete(connObj, &chip::Ble::CHIP_BLE_SVC_ID, &uuid);
+
+exit:
+    env->ReleaseStringUTFChars(charId, charIdStr);
 }
 
 JNI_METHOD(jboolean, isConnected)(JNIEnv * env, jobject self, jlong deviceControllerPtr)

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -115,9 +115,6 @@ private:
     pthread_mutex_t * mMutex;
 };
 
-} // namespace
-
-namespace {
 // Use StackUnlockGuard to temporarily unlock the CHIP BLE stack, e.g. when calling application
 // or Android BLE code as a result of a BLE event.
 struct StackUnlockGuard

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -424,7 +424,8 @@ exit:
     return result;
 }
 
-JNI_METHOD(void, handleIndicationReceived)(JNIEnv * env, jobject self, jint conn, jbyteArray svcId, jbyteArray charId, jbyteArray value)
+JNI_METHOD(void, handleIndicationReceived)
+(JNIEnv * env, jobject self, jint conn, jbyteArray svcId, jbyteArray charId, jbyteArray value)
 {
     BLE_CONNECTION_OBJECT const connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(conn);
     const auto valueBegin               = env->GetByteArrayElements(value, nullptr);
@@ -432,7 +433,7 @@ JNI_METHOD(void, handleIndicationReceived)(JNIEnv * env, jobject self, jint conn
 
     chip::Ble::ChipBleUUID svcUUID;
     chip::Ble::ChipBleUUID charUUID;
-    chip::System::PacketBuffer* buffer = nullptr;
+    chip::System::PacketBuffer * buffer = nullptr;
 
     VerifyOrExit(JavaBytesToUUID(env, svcId, svcUUID),
                  ChipLogError(Controller, "handleIndicationReceived() called with invalid service ID"));
@@ -503,7 +504,6 @@ JNI_METHOD(void, handleConnectionError)(JNIEnv * env, jobject self, jint conn)
     BLE_CONNECTION_OBJECT const connObj = reinterpret_cast<BLE_CONNECTION_OBJECT>(conn);
     sBleLayer.HandleConnectionError(connObj, BLE_ERROR_APP_CLOSED_CONNECTION);
 }
-
 
 JNI_METHOD(jboolean, isConnected)(JNIEnv * env, jobject self, jlong deviceControllerPtr)
 {

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -460,7 +460,7 @@ JNI_METHOD(void, handleWriteConfirmation)(JNIEnv * env, jobject self, jint conn,
                  ChipLogError(Controller, "handleWriteConfirmation() called with invalid service ID"));
     VerifyOrExit(JavaBytesToUUID(env, charId, charUUID),
                  ChipLogError(Controller, "handleWriteConfirmation() called with invalid characteristic ID"));
-                 
+
     sBleLayer.HandleWriteConfirmation(connObj, &svcUUID, &charUUID);
 exit:
     return;

--- a/src/controller/java/src/chip/devicecontroller/AndroidChipStack.java
+++ b/src/controller/java/src/chip/devicecontroller/AndroidChipStack.java
@@ -65,6 +65,96 @@ public final class AndroidChipStack {
     }
   }
 
+  public static class ChipGattCallback extends BluetoothGattCallback {
+    @Override
+    public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
+      if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+        int connId = getInstance().getConnId(gatt);
+        ChipDeviceController controller = getInstance().getConnection(connId);
+
+        if (controller == null) {
+          Log.e(TAG, "onConnectionStateChange disconnected: no active connection");
+          return;
+        }
+        Log.d(TAG, "onConnectionStateChange Disconnected");
+        controller.handleConnectionError(connId);
+      }
+    }
+
+    @Override
+    public void onCharacteristicWrite(
+        BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
+      if (status != BluetoothGatt.GATT_SUCCESS) {
+        Log.e(TAG, "onCharacteristicWrite for "
+                + characteristic.getUuid().toString()
+                + " failed with status: "
+                + status);
+        return;
+      }
+
+      int connId = getInstance().getConnId(gatt);
+      ChipDeviceController controller = getInstance().getConnection(connId);
+
+      if (controller == null) {
+        Log.e(TAG, "onCharacteristicWrite no active connection");
+        return;
+      }
+
+      byte[] svcIdBytes = convertUUIDToBytes(characteristic.getService().getUuid());
+      byte[] charIdBytes = convertUUIDToBytes(characteristic.getUuid());
+      controller.handleWriteConfirmation(connId, svcIdBytes, charIdBytes);
+    }
+
+    @Override
+    public void onCharacteristicChanged(
+        BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
+      int connId = getInstance().getConnId(gatt);
+      ChipDeviceController controller = getInstance().getConnection(connId);
+
+      if (controller == null) {
+        Log.e(TAG, "onCharacteristicChanged no active connection");
+        return;
+      }
+
+      byte[] svcIdBytes = convertUUIDToBytes(characteristic.getService().getUuid());
+      byte[] charIdBytes = convertUUIDToBytes(characteristic.getUuid());
+      controller.handleIndicationReceived(connId, svcIdBytes, charIdBytes, characteristic.getValue());
+    }
+
+    @Override
+    public void onDescriptorWrite(
+        BluetoothGatt gatt, BluetoothGattDescriptor desc, int status) {
+      BluetoothGattCharacteristic characteristic = desc.getCharacteristic();
+      if (status != BluetoothGatt.GATT_SUCCESS) {
+        Log.e(
+            TAG,
+            "onDescriptorWrite for "
+                + desc.getUuid().toString()
+                + " failed with status: "
+                + status);
+      }
+
+      int connId = getInstance().getConnId(gatt);
+      ChipDeviceController controller = getInstance().getConnection(connId);
+
+      if (controller == null) {
+        Log.e(TAG, "onDescriptorWrite no active connection");
+        return;
+      }
+
+      byte[] svcIdBytes = convertUUIDToBytes(characteristic.getService().getUuid());
+      byte[] charIdBytes = convertUUIDToBytes(characteristic.getUuid());
+
+      if (desc.getValue() == BluetoothGattDescriptor.ENABLE_INDICATION_VALUE) {
+        controller.handleSubscribeComplete(connId, svcIdBytes, charIdBytes);
+      } else if (desc.getValue() == BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE) {
+        controller.handleUnsubscribeComplete(connId, svcIdBytes, charIdBytes);
+      } else {
+        Log.d(TAG, "Unexpected onDescriptorWrite().");
+      }
+    }
+  }
+
   /* Singleton instance of this class */
   private static final AndroidChipStack sInstance = new AndroidChipStack();
 
@@ -75,116 +165,10 @@ public final class AndroidChipStack {
 
   private AndroidChipStack() {
     mConnections = new ArrayList<ChipDeviceController>(INITIAL_CONNECTIONS);
-    mGattCallback =
-        new BluetoothGattCallback() {
-          @Override
-          public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
-            int connId = 0;
-
-            if (newState == BluetoothProfile.STATE_DISCONNECTED) {
-              connId = getConnId(gatt);
-              if (connId > 0) {
-                Log.d(TAG, "onConnectionStateChange Disconnected");
-                handleConnectionError(connId);
-              } else {
-                Log.e(TAG, "onConnectionStateChange disconnected: no active connection");
-              }
-            }
-          }
-
-          @Override
-          public void onServicesDiscovered(BluetoothGatt gatt, int status) {}
-
-          @Override
-          public void onCharacteristicRead(
-              BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {}
-
-          @Override
-          public void onCharacteristicWrite(
-              BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
-            byte[] svcIdBytes = convertUUIDToBytes(characteristic.getService().getUuid());
-            byte[] charIdBytes = convertUUIDToBytes(characteristic.getUuid());
-
-            if (status != BluetoothGatt.GATT_SUCCESS) {
-              Log.e(
-                  TAG,
-                  "onCharacteristicWrite for "
-                      + characteristic.getUuid().toString()
-                      + " failed with status: "
-                      + status);
-              return;
-            }
-
-            int connId = getConnId(gatt);
-            if (connId > 0) {
-              handleWriteConfirmation(
-                  connId, svcIdBytes, charIdBytes, status == BluetoothGatt.GATT_SUCCESS);
-            } else {
-              Log.e(TAG, "onCharacteristicWrite no active connection");
-              return;
-            }
-          }
-
-          @Override
-          public void onCharacteristicChanged(
-              BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
-            byte[] svcIdBytes = convertUUIDToBytes(characteristic.getService().getUuid());
-            byte[] charIdBytes = convertUUIDToBytes(characteristic.getUuid());
-            int connId = getConnId(gatt);
-            if (connId > 0) {
-              handleIndicationReceived(connId, svcIdBytes, charIdBytes, characteristic.getValue());
-            } else {
-              Log.e(TAG, "onCharacteristicChanged no active connection");
-              return;
-            }
-          }
-
-          @Override
-          public void onDescriptorWrite(
-              BluetoothGatt gatt, BluetoothGattDescriptor desc, int status) {
-            BluetoothGattCharacteristic characteristic = desc.getCharacteristic();
-
-            byte[] svcIdBytes = convertUUIDToBytes(characteristic.getService().getUuid());
-            byte[] charIdBytes = convertUUIDToBytes(characteristic.getUuid());
-
-            if (status != BluetoothGatt.GATT_SUCCESS) {
-              Log.e(
-                  TAG,
-                  "onDescriptorWrite for "
-                      + desc.getUuid().toString()
-                      + " failed with status: "
-                      + status);
-            }
-
-            int connId = getConnId(gatt);
-            if (connId == 0) {
-              Log.e(TAG, "onDescriptorWrite no active connection");
-              return;
-            }
-
-            if (desc.getValue() == BluetoothGattDescriptor.ENABLE_INDICATION_VALUE) {
-              handleSubscribeComplete(
-                  connId, svcIdBytes, charIdBytes, status == BluetoothGatt.GATT_SUCCESS);
-            } else if (desc.getValue() == BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE) {
-              handleUnsubscribeComplete(
-                  connId, svcIdBytes, charIdBytes, status == BluetoothGatt.GATT_SUCCESS);
-            } else {
-              Log.d(TAG, "Unexpected onDescriptorWrite().");
-            }
-          }
-
-          @Override
-          public void onDescriptorRead(
-              BluetoothGatt gatt, BluetoothGattDescriptor desc, int status) {}
-        };
   }
 
   public static AndroidChipStack getInstance() {
     return sInstance;
-  }
-
-  public BluetoothGattCallback getCallback() {
-    return mGattCallback;
   }
 
   public synchronized ChipDeviceController getConnection(int connId) {
@@ -365,24 +349,6 @@ public final class AndroidChipStack {
   }
 
   // ----- Private Members -----
-
-  static {
-    System.loadLibrary("CHIPController");
-  }
-
-  private native void handleWriteConfirmation(
-      int connId, byte[] svcId, byte[] charId, boolean success);
-
-  private native void handleIndicationReceived(
-      int connId, byte[] svcId, byte[] charId, byte[] data);
-
-  private native void handleSubscribeComplete(
-      int connId, byte[] svcId, byte[] charId, boolean success);
-
-  private native void handleUnsubscribeComplete(
-      int connId, byte[] svcId, byte[] charId, boolean success);
-
-  private native void handleConnectionError(int connId);
 
   // CLIENT_CHARACTERISTIC_CONFIG is the well-known UUID of the client characteristic descriptor
   // that has the flags for enabling and disabling notifications and indications.

--- a/src/controller/java/src/chip/devicecontroller/AndroidChipStack.java
+++ b/src/controller/java/src/chip/devicecontroller/AndroidChipStack.java
@@ -85,7 +85,9 @@ public final class AndroidChipStack {
     public void onCharacteristicWrite(
         BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
       if (status != BluetoothGatt.GATT_SUCCESS) {
-        Log.e(TAG, "onCharacteristicWrite for "
+        Log.e(
+            TAG,
+            "onCharacteristicWrite for "
                 + characteristic.getUuid().toString()
                 + " failed with status: "
                 + status);
@@ -118,12 +120,12 @@ public final class AndroidChipStack {
 
       byte[] svcIdBytes = convertUUIDToBytes(characteristic.getService().getUuid());
       byte[] charIdBytes = convertUUIDToBytes(characteristic.getUuid());
-      controller.handleIndicationReceived(connId, svcIdBytes, charIdBytes, characteristic.getValue());
+      controller.handleIndicationReceived(
+          connId, svcIdBytes, charIdBytes, characteristic.getValue());
     }
 
     @Override
-    public void onDescriptorWrite(
-        BluetoothGatt gatt, BluetoothGattDescriptor desc, int status) {
+    public void onDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptor desc, int status) {
       BluetoothGattCharacteristic characteristic = desc.getCharacteristic();
       if (status != BluetoothGatt.GATT_SUCCESS) {
         Log.e(

--- a/src/controller/java/src/chip/devicecontroller/AndroidChipStack.java
+++ b/src/controller/java/src/chip/devicecontroller/AndroidChipStack.java
@@ -68,17 +68,20 @@ public final class AndroidChipStack {
   public static class ChipGattCallback extends BluetoothGattCallback {
     @Override
     public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
-      if (newState == BluetoothProfile.STATE_DISCONNECTED) {
-        int connId = getInstance().getConnId(gatt);
-        ChipDeviceController controller = getInstance().getConnection(connId);
-
-        if (controller == null) {
-          Log.e(TAG, "onConnectionStateChange disconnected: no active connection");
-          return;
-        }
-        Log.d(TAG, "onConnectionStateChange Disconnected");
-        controller.handleConnectionError(connId);
+      if (status != BluetoothGatt.GATT_SUCCESS || newState != BluetoothProfile.STATE_DISCONNECTED) {
+        return;
       }
+
+      int connId = getInstance().getConnId(gatt);
+      ChipDeviceController controller = getInstance().getConnection(connId);
+
+      if (controller == null) {
+        Log.e(TAG, "onConnectionStateChange disconnected: no active connection");
+        return;
+      }
+
+      Log.d(TAG, "onConnectionStateChange Disconnected");
+      controller.handleConnectionError(connId);
     }
 
     @Override

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -18,11 +18,6 @@
 package chip.devicecontroller;
 
 import android.bluetooth.BluetoothGatt;
-import android.bluetooth.BluetoothGattCallback;
-import android.bluetooth.BluetoothGattCharacteristic;
-import android.bluetooth.BluetoothGattService;
-import android.bluetooth.BluetoothGattDescriptor;
-import java.util.UUID;
 import android.util.Log;
 
 /** Controller to interact with the CHIP device. */
@@ -120,8 +115,7 @@ public class ChipDeviceController {
 
   public native void handleWriteConfirmation(int connId, byte[] svcId, byte[] charId);
 
-  public native void handleIndicationReceived(
-      int connId, byte[] svcId, byte[] charId, byte[] data);
+  public native void handleIndicationReceived(int connId, byte[] svcId, byte[] charId, byte[] data);
 
   public native void handleSubscribeComplete(int connId, byte[] svcId, byte[] charId);
 

--- a/src/transport/RendezvousParameters.h
+++ b/src/transport/RendezvousParameters.h
@@ -33,6 +33,8 @@ class RendezvousParameters
 public:
     RendezvousParameters() = default;
 
+    bool IsController() const { return HasDiscriminator() || HasConnectionObject(); }
+
     bool HasSetupPINCode() const { return mSetupPINCode != 0; }
     uint32_t GetSetupPINCode() const { return mSetupPINCode; }
     RendezvousParameters & SetSetupPINCode(uint32_t setupPINCode)
@@ -73,6 +75,8 @@ public:
         mConnectionObject = connObj;
         return *this;
     }
+#else
+    bool HasConnectionObject() const { return false; }
 #endif // CONFIG_NETWORK_LAYER_BLE
 
 private:

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -57,7 +57,7 @@ CHIP_ERROR RendezvousSession::Init(const RendezvousParameters & params)
 #endif // CONFIG_NETWORK_LAYER_BLE
     SuccessOrExit(err);
 
-    if (!mParams.HasDiscriminator() && !mParams.HasConnectionObject())
+    if (!mParams.IsController())
     {
         err = WaitForPairing(mParams.GetLocalNodeId(), mParams.GetSetupPINCode());
         SuccessOrExit(err);
@@ -211,7 +211,7 @@ void RendezvousSession::OnNetworkProvisioningComplete()
 
 void RendezvousSession::OnRendezvousConnectionOpened()
 {
-    if (mParams.HasDiscriminator() || mParams.HasConnectionObject())
+    if (mParams.IsController())
     {
         CHIP_ERROR err = Pair(mParams.GetLocalNodeId(), mParams.GetSetupPINCode());
         VerifyOrExit(err == CHIP_NO_ERROR, OnPairingError(err));
@@ -223,7 +223,7 @@ exit:
 
 void RendezvousSession::OnRendezvousConnectionClosed()
 {
-    if (!mParams.HasDiscriminator() && !mParams.HasConnectionObject())
+    if (!mParams.IsController())
     {
         mSecureSession.Reset();
         CHIP_ERROR err = WaitForPairing(mParams.GetLocalNodeId(), mParams.GetSetupPINCode());

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -57,7 +57,7 @@ CHIP_ERROR RendezvousSession::Init(const RendezvousParameters & params)
 #endif // CONFIG_NETWORK_LAYER_BLE
     SuccessOrExit(err);
 
-    if (!mParams.HasDiscriminator())
+    if (!mParams.HasDiscriminator() && !mParams.HasConnectionObject())
     {
         err = WaitForPairing(mParams.GetLocalNodeId(), mParams.GetSetupPINCode());
         SuccessOrExit(err);
@@ -211,7 +211,7 @@ void RendezvousSession::OnNetworkProvisioningComplete()
 
 void RendezvousSession::OnRendezvousConnectionOpened()
 {
-    if (mParams.HasDiscriminator())
+    if (mParams.HasDiscriminator() || mParams.HasConnectionObject())
     {
         CHIP_ERROR err = Pair(mParams.GetLocalNodeId(), mParams.GetSetupPINCode());
         VerifyOrExit(err == CHIP_NO_ERROR, OnPairingError(err));


### PR DESCRIPTION
 #### Problem
Android CHIPTool has incomplete implementation of rendezvous over BLE.

 #### Summary of Changes
* Pass Bluetooth Gatt events to CHIP BleLayer
* Fix RendezvousSession in case connection object is given in RendezvousParams instead of discriminator
* Call beginConnectBle() in "Rendezvous over BLE" button handler to initiate secure connection to the device

Note that network provisioning part is still missing.
