### PR TITLE
[android/CHIPTool] During Rendezvous over BLE use Thread credentials retrieved from OTBR

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/thread/ThreadNetworkCredential.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/thread/ThreadNetworkCredential.java
@@ -24,16 +24,37 @@ import androidx.annotation.NonNull;
 import com.google.chip.chiptool.commissioner.NetworkCredential;
 
 public class ThreadNetworkCredential implements NetworkCredential, Parcelable {
+  private final int channel;
+  private final int panid;
+  @NonNull private final byte[] xpanid;
+  @NonNull private final byte[] meshPrefix;
+  @NonNull private final byte[] masterKey;
 
-  @NonNull private final byte[] activeOperationalDataset;
-
-  public ThreadNetworkCredential(@NonNull byte[] activeOperationalDataset) {
-    this.activeOperationalDataset = activeOperationalDataset;
+  public ThreadNetworkCredential(int channel,
+                                 int panid,
+                                 @NonNull byte[] xpanid,
+                                 @NonNull byte[] meshPrefix,
+                                 @NonNull byte[] masterKey) {
+    this.channel = channel;
+    this.panid = panid;
+    this.xpanid = xpanid;
+    this.meshPrefix = meshPrefix;
+    this.masterKey = masterKey;
   }
 
-  protected ThreadNetworkCredential(Parcel in) {
-    activeOperationalDataset = in.createByteArray();
+  private ThreadNetworkCredential(Parcel in) {
+    this(in.readInt(), in.readInt(), in.createByteArray(), in.createByteArray(), in.createByteArray());
   }
+
+  public ThreadNetworkCredential(byte[] encoded) {
+    this(makeParcel(encoded));
+  }
+
+  public int getChannel() { return channel; }
+  public int getPanid() { return panid; }
+  @NonNull public byte[] getXpanid() { return xpanid; }
+  @NonNull public byte[] getMeshPrefix() { return meshPrefix; }
+  @NonNull public byte[] getMasterKey() { return masterKey; }
 
   public static final Creator<ThreadNetworkCredential> CREATOR =
       new Creator<ThreadNetworkCredential>() {
@@ -48,15 +69,6 @@ public class ThreadNetworkCredential implements NetworkCredential, Parcelable {
         }
       };
 
-  public byte[] getActiveOperationalDataset() {
-    return activeOperationalDataset;
-  }
-
-  @Override
-  public byte[] getEncoded() {
-    return activeOperationalDataset;
-  }
-
   @Override
   public int describeContents() {
     return 0;
@@ -64,6 +76,26 @@ public class ThreadNetworkCredential implements NetworkCredential, Parcelable {
 
   @Override
   public void writeToParcel(Parcel parcel, int i) {
-    parcel.writeByteArray(activeOperationalDataset);
+    parcel.writeInt(this.channel);
+    parcel.writeInt(this.panid);
+    parcel.writeByteArray(this.xpanid);
+    parcel.writeByteArray(this.meshPrefix);
+    parcel.writeByteArray(this.masterKey);
+  }
+
+  @Override
+  public byte[] getEncoded() {
+    Parcel parcel = Parcel.obtain();
+    this.writeToParcel(parcel, 0);
+    byte[] encoded = parcel.marshall();
+    parcel.recycle();
+    return encoded;
+  }
+
+  private static Parcel makeParcel(byte[] encoded) {
+    Parcel parcel = Parcel.obtain();
+    parcel.unmarshall(encoded, 0, encoded.length);
+    parcel.setDataPosition(0);
+    return parcel;
   }
 }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/thread/internal/CommissioningFragment.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/thread/internal/CommissioningFragment.java
@@ -90,8 +90,9 @@ public class CommissioningFragment extends Fragment {
               commissionerActivity.finishCommissioning(Activity.RESULT_OK);
             });
 
-    ChipClient.INSTANCE.getDeviceController().setThreadCredentials(this.networkCredential.getPanid(),
+    ChipClient.INSTANCE.getDeviceController().setThreadCredentials(
             this.networkCredential.getChannel(),
+            this.networkCredential.getPanid(),
             this.networkCredential.getXpanid(),
             this.networkCredential.getMeshPrefix(),
             this.networkCredential.getMasterKey());

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/thread/internal/CommissioningFragment.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/thread/internal/CommissioningFragment.java
@@ -29,9 +29,15 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+
+import com.google.chip.chiptool.ChipClient;
 import com.google.chip.chiptool.R;
 import com.google.chip.chiptool.commissioner.CommissionerActivity;
 import com.google.chip.chiptool.commissioner.thread.ThreadNetworkCredential;
+
+import chip.devicecontroller.ChipDeviceController;
+import io.openthread.commissioner.ActiveOperationalDataset;
+import io.openthread.commissioner.Commissioner;
 
 public class CommissioningFragment extends Fragment {
 
@@ -84,8 +90,12 @@ public class CommissioningFragment extends Fragment {
               commissionerActivity.finishCommissioning(Activity.RESULT_OK);
             });
 
-    // TODO: commissioning over BLE.
-    showCommissionDone(false, "Commissioning over BLE not implemented yet!");
+    ChipClient.INSTANCE.getDeviceController().setThreadCredentials(this.networkCredential.getPanid(),
+            this.networkCredential.getChannel(),
+            this.networkCredential.getXpanid(),
+            this.networkCredential.getMeshPrefix(),
+            this.networkCredential.getMasterKey());
+    showCommissionDone(true, "Thread credentials set");
   }
 
   private void showInProgress(String status) {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/thread/internal/NetworkCredentialFetcher.java
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/commissioner/thread/internal/NetworkCredentialFetcher.java
@@ -24,6 +24,8 @@ import com.google.chip.chiptool.commissioner.thread.BorderAgentInfo;
 import com.google.chip.chiptool.commissioner.thread.CommissionerUtils;
 import com.google.chip.chiptool.commissioner.thread.ThreadCommissionerException;
 import com.google.chip.chiptool.commissioner.thread.ThreadNetworkCredential;
+
+import io.openthread.commissioner.ActiveOperationalDataset;
 import io.openthread.commissioner.ByteArray;
 import io.openthread.commissioner.ChannelMask;
 import io.openthread.commissioner.Commissioner;
@@ -45,9 +47,7 @@ class NetworkCredentialFetcher {
   public ThreadNetworkCredential fetchNetworkCredential(
       @NonNull BorderAgentInfo borderAgentInfo, @NonNull byte[] pskc)
       throws ThreadCommissionerException {
-    byte[] rawActiveDataset =
-        fetchNetworkCredential(borderAgentInfo.host, borderAgentInfo.port, pskc);
-    return new ThreadNetworkCredential(rawActiveDataset);
+    return fetchNetworkCredential(borderAgentInfo.host, borderAgentInfo.port, pskc);
   }
 
   public void cancel() {
@@ -57,7 +57,7 @@ class NetworkCredentialFetcher {
     }
   }
 
-  private byte[] fetchNetworkCredential(
+  private ThreadNetworkCredential fetchNetworkCredential(
       @NonNull InetAddress address, int port, @NonNull byte[] pskc)
       throws ThreadCommissionerException {
     nativeCommissioner = Commissioner.create(nativeCommissionerHandler);
@@ -80,15 +80,16 @@ class NetworkCredentialFetcher {
           nativeCommissioner.petition(existingCommissionerId, address.getHostAddress(), port));
 
       // Fetch Active Operational Dataset.
-      ByteArray rawActiveDataset = new ByteArray();
-      throwIfFail(nativeCommissioner.getRawActiveDataset(rawActiveDataset, 0xFFFF));
+      ActiveOperationalDataset activeDataset = new ActiveOperationalDataset();
+      throwIfFail(nativeCommissioner.getActiveDataset(activeDataset, 0xFFFF));
+      return new ThreadNetworkCredential(activeDataset.getChannel().getNumber(),
+              activeDataset.getPanId(),
+              CommissionerUtils.getByteArray(activeDataset.getExtendedPanId()),
+              CommissionerUtils.getByteArray(activeDataset.getMeshLocalPrefix()),
+              CommissionerUtils.getByteArray(activeDataset.getNetworkMasterKey()));
+    } finally {
       nativeCommissioner.resign();
       nativeCommissioner = null;
-      return CommissionerUtils.getByteArray(rawActiveDataset);
-    } catch (ThreadCommissionerException e) {
-      nativeCommissioner.resign();
-      nativeCommissioner = null;
-      throw e;
     }
   }
 

--- a/src/controller/java/AndroidDevicePairingDelegate.cpp
+++ b/src/controller/java/AndroidDevicePairingDelegate.cpp
@@ -20,32 +20,28 @@
 
 #include <transport/RendezvousSessionDelegate.h>
 
-void AndroidDevicePairingDelegate::OnNetworkCredentialsRequested(chip::RendezvousDeviceCredentialsDelegate * callback)
+AndroidDevicePairingDelegate::AndroidDevicePairingDelegate()
 {
     using namespace chip::DeviceLayer::Internal;
 
-    // This is a dummy implementation of Thread provisioning which allows to test Rendezvous over BLE with
-    // Thread-enabled devices by sending OpenThread Border Router default credentials.
-    //
-    // TODO:
-    // 1. Figure out whether WiFi or Thread provisioning should be performed
-    // 2. Call Java code to prompt a user for credentials or use the commissioner component of the app
-
     constexpr uint8_t XPAN_ID[kThreadExtendedPANIdLength]  = { 0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22 };
     constexpr uint8_t MESH_PREFIX[kThreadMeshPrefixLength] = { 0xFD, 0x11, 0x11, 0x11, 0x11, 0x22, 0x00, 0x00 };
-    constexpr uint8_t NETWORK_KEY[kThreadMasterKeyLength]  = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
-                                                              0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
+    constexpr uint8_t MASTER_KEY[kThreadMasterKeyLength]   = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                                             0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
 
-    DeviceNetworkInfo threadData = {};
-    memcpy(threadData.ThreadExtendedPANId, XPAN_ID, sizeof(XPAN_ID));
-    memcpy(threadData.ThreadMeshPrefix, MESH_PREFIX, sizeof(MESH_PREFIX));
-    memcpy(threadData.ThreadMasterKey, NETWORK_KEY, sizeof(NETWORK_KEY));
-    threadData.ThreadPANId                      = 0x1234;
-    threadData.ThreadChannel                    = 15;
-    threadData.FieldPresent.ThreadExtendedPANId = 1;
-    threadData.FieldPresent.ThreadMeshPrefix    = 1;
+    memcpy(mThreadData.ThreadExtendedPANId, XPAN_ID, sizeof(XPAN_ID));
+    memcpy(mThreadData.ThreadMeshPrefix, MESH_PREFIX, sizeof(MESH_PREFIX));
+    memcpy(mThreadData.ThreadMasterKey, MASTER_KEY, sizeof(MASTER_KEY));
+    mThreadData.ThreadPANId                      = 0x1234;
+    mThreadData.ThreadChannel                    = 15;
+    mThreadData.FieldPresent.ThreadExtendedPANId = 1;
+    mThreadData.FieldPresent.ThreadMeshPrefix    = 1;
+}
 
-    callback->SendThreadCredentials(threadData);
+void AndroidDevicePairingDelegate::OnNetworkCredentialsRequested(chip::RendezvousDeviceCredentialsDelegate * callback)
+{
+    // TODO: Figure out whether WiFi or Thread provisioning should be performed
+    callback->SendThreadCredentials(mThreadData);
 }
 
 void AndroidDevicePairingDelegate::OnOperationalCredentialsRequested(const char * csr, size_t csr_length,

--- a/src/controller/java/AndroidDevicePairingDelegate.h
+++ b/src/controller/java/AndroidDevicePairingDelegate.h
@@ -19,11 +19,21 @@
 #pragma once
 
 #include <controller/CHIPDeviceController.h>
+#include <platform/internal/DeviceNetworkInfo.h>
 
 class AndroidDevicePairingDelegate : public chip::DeviceController::DevicePairingDelegate
 {
 public:
+    using DeviceNetworkInfo = chip::DeviceLayer::Internal::DeviceNetworkInfo;
+
+    AndroidDevicePairingDelegate();
+
+    void SetThreadCredentials(const DeviceNetworkInfo & threadData) { mThreadData = threadData; }
+
     void OnNetworkCredentialsRequested(chip::RendezvousDeviceCredentialsDelegate * callback) override;
     void OnOperationalCredentialsRequested(const char * csr, size_t csr_length,
                                            chip::RendezvousDeviceCredentialsDelegate * callback) override;
+
+private:
+    DeviceNetworkInfo mThreadData = {};
 };

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -115,6 +115,8 @@ public class ChipDeviceController {
     completionListener.onError(error);
   }
 
+  public native void setThreadCredentials(int channel, int panid, byte[] xpanid, byte[] prefix, byte[] masterKey);
+
   /* BluetoothGattCallback handlers */
 
   public native void handleWriteConfirmation(int connId, byte[] svcId, byte[] charId);


### PR DESCRIPTION
Send data collected in the "Commissioner" wizard of CHIPTool during Rendezvous over BLE phase. Note that the change won't be published for now until the planned reorganization of the app (being done by Google) is ready. It's yet to prove that the whole solution will work as expected.

To test the solution you need to first go to "Commissioner" screen of the CHIPTool app and retrieve Thread credentials from OTBR. After that you must switch to "Scan QR Code" screen and proceed with Rendezvous over BLE normally. 