### PR TITLE
[nrfconnect] Use test pairing without rendezvous bypass

### DIFF
--- a/examples/lighting-app/nrfconnect/main/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/nrfconnect/main/include/CHIPProjectConfig.h
@@ -30,3 +30,4 @@
 // Use a default pairing code if one hasn't been provisioned in flash.
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 12345678
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+#define CHIP_DEVICE_CONFIG_USE_TEST_PAIRING 1

--- a/examples/lock-app/nrfconnect/main/include/CHIPProjectConfig.h
+++ b/examples/lock-app/nrfconnect/main/include/CHIPProjectConfig.h
@@ -30,3 +30,4 @@
 // Use a default pairing code if one hasn't been provisioned in flash.
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 12345678
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+#define CHIP_DEVICE_CONFIG_USE_TEST_PAIRING 1

--- a/examples/shell/nrfconnect/CHIPProjectConfig.h
+++ b/examples/shell/nrfconnect/CHIPProjectConfig.h
@@ -30,6 +30,7 @@
 // Use a default pairing code if one hasn't been provisioned in flash.
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 12345678
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+#define CHIP_DEVICE_CONFIG_USE_TEST_PAIRING 1
 
 // Enable support functions for parsing command-line arguments
 #define CHIP_CONFIG_ENABLE_ARG_PARSER 1

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -47,19 +47,26 @@ using namespace ::chip::Messaging;
 
 namespace {
 
-bool isRendezvousBypassed()
+constexpr bool isRendezvousBypassed()
 {
-    RendezvousInformationFlags rendezvousMode = RendezvousInformationFlags::kBLE;
-
-#ifdef CONFIG_RENDEZVOUS_MODE
-    rendezvousMode = static_cast<RendezvousInformationFlags>(CONFIG_RENDEZVOUS_MODE);
+#if defined(CHIP_BYPASS_RENDEZVOUS) && CHIP_BYPASS_RENDEZVOUS
+    return true;
+#elif defined(CONFIG_RENDEZVOUS_MODE)
+    return static_cast<RendezvousInformationFlags>(CONFIG_RENDEZVOUS_MODE) == RendezvousInformationFlags::kNone;
+#else
+    return false;
 #endif
+}
 
-#ifdef CHIP_BYPASS_RENDEZVOUS
-    rendezvousMode = RendezvousInformationFlags::kNone;
+constexpr bool useTestPairing()
+{
+#if defined(CHIP_DEVICE_CONFIG_USE_TEST_PAIRING) && CHIP_DEVICE_CONFIG_USE_TEST_PAIRING
+    return true;
+#else
+    // Use the test pairing whenever rendezvous is bypassed. Otherwise, there wouldn't be
+    // any way to communicate with the device using CHIP protocol.
+    return isRendezvousBypassed();
 #endif
-
-    return rendezvousMode == RendezvousInformationFlags::kNone;
 }
 
 class ServerRendezvousAdvertisementDelegate : public RendezvousAdvertisementDelegate
@@ -263,16 +270,20 @@ void InitServer(AppDelegate * delegate)
     gSessions.SetDelegate(&gCallbacks);
 #endif
 
-    // This flag is used to bypass BLE in the cirque test
-    // Only in the cirque test this is enabled with --args='bypass_rendezvous=true'
-    if (isRendezvousBypassed())
+    if (useTestPairing())
     {
         AdminPairingInfo * adminInfo = gAdminPairings.AssignAdminId(gNextAvailableAdminId);
         VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
         adminInfo->SetNodeId(chip::kTestDeviceNodeId);
-        ChipLogProgress(AppServer, "Rendezvous and Secure Pairing skipped. Using test secret.");
         err = gSessions.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, gNextAvailableAdminId);
         SuccessOrExit(err);
+    }
+
+    // This flag is used to bypass BLE in the cirque test
+    // Only in the cirque test this is enabled with --args='bypass_rendezvous=true'
+    if (isRendezvousBypassed())
+    {
+        ChipLogProgress(AppServer, "Rendezvous and secure pairing skipped");
     }
     else if (DeviceLayer::ConnectivityMgr().IsWiFiStationProvisioned() || DeviceLayer::ConnectivityMgr().IsThreadProvisioned())
     {


### PR DESCRIPTION
Since #4401 has been merged, the test pairing/secret is
added to the session manager only if rendezvous is bypassed.
However, we would like to keep the possibility to test
nRF Connect examples with and without the full rendezvous
procedure without the need to recompile a project with
different settings.

Add a setting CHIP_DEVICE_CONFIG_USE_TEST_PAIRING which
allows to initialize the session manager with the test
secret even if rendezvous bypass mode is not used.
