### PR TITLE
[workflows] Cancel expired runs after updating a PR

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -19,6 +19,14 @@ on:
     pull_request:
 
 jobs:
+    cancel-expired-runs:
+        runs-on: ubuntu-latest
+        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+        steps:
+        - uses: rokroskar/workflow-run-cleanup-action@master
+          env:
+              GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
     build:
         name: Build
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,14 @@ on:
     pull_request:
 
 jobs:
+    cancel-expired-runs:
+        runs-on: ubuntu-latest
+        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+        steps:
+        - uses: rokroskar/workflow-run-cleanup-action@master
+          env:
+              GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
     build:
         name: Build
 

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -19,6 +19,14 @@ on:
     pull_request:
 
 jobs:
+    cancel-expired-runs:
+        runs-on: ubuntu-latest
+        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+        steps:
+        - uses: rokroskar/workflow-run-cleanup-action@master
+          env:
+              GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
     build:
         name: Cirque
 

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -19,6 +19,14 @@ on:
     pull_request:
 
 jobs:
+    cancel-expired-runs:
+        runs-on: ubuntu-latest
+        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+        steps:
+        - uses: rokroskar/workflow-run-cleanup-action@master
+          env:
+              GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
     build:
         name: Generate
 

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -19,6 +19,14 @@ on:
     pull_request:
 
 jobs:
+    cancel-expired-runs:
+        runs-on: ubuntu-latest
+        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+        steps:
+        - uses: rokroskar/workflow-run-cleanup-action@master
+          env:
+              GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
     efr32:
         name: EFR32
         env:

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -19,6 +19,14 @@ on:
     pull_request:
 
 jobs:
+    cancel-expired-runs:
+        runs-on: ubuntu-latest
+        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+        steps:
+        - uses: rokroskar/workflow-run-cleanup-action@master
+          env:
+              GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
     # TODO ESP32 https://github.com/project-chip/connectedhomeip/issues/1510
     esp32:
         name: ESP32

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -19,6 +19,14 @@ on:
     pull_request:
 
 jobs:
+    cancel-expired-runs:
+        runs-on: ubuntu-latest
+        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+        steps:
+        - uses: rokroskar/workflow-run-cleanup-action@master
+          env:
+              GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
     linux-standalone:
         name: Linux Standalone
 

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -19,6 +19,14 @@ on:
     pull_request:
 
 jobs:
+    cancel-expired-runs:
+        runs-on: ubuntu-latest
+        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+        steps:
+        - uses: rokroskar/workflow-run-cleanup-action@master
+          env:
+              GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
     nrfconnect:
         name: nRF Connect SDK
         env:

--- a/.github/workflows/examples-qpg6100.yaml
+++ b/.github/workflows/examples-qpg6100.yaml
@@ -19,6 +19,14 @@ on:
     pull_request:
 
 jobs:
+    cancel-expired-runs:
+        runs-on: ubuntu-latest
+        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+        steps:
+        - uses: rokroskar/workflow-run-cleanup-action@master
+          env:
+              GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
     qpg6100:
         name: QPG6100
         env:

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -19,6 +19,14 @@ on:
     pull_request:
 
 jobs:
+    cancel-expired-runs:
+        runs-on: ubuntu-latest
+        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+        steps:
+        - uses: rokroskar/workflow-run-cleanup-action@master
+          env:
+              GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
     examples:
         name: ESP32
 


### PR DESCRIPTION
Currently, when a PR is updated and the previous CI checks
for the PR have already started, the CI will needlessly
keep executing the started tasks even though their results
are no longer relevant. Incorporate:
https://github.com/rokroskar/workflow-run-cleanup-action
to remove the expired tasks from the queue so that we get
relevant CI results faster.