### PR TITLE
[nrfconnect] Use OpenThread API to join/leave multicast groups

### DIFF
--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -108,6 +108,11 @@ union PeerSockAddr
 };
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
+#if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+IPEndPointBasis::JoinMulticastGroupHandler IPEndPointBasis::sJoinMulticastGroupHandler;
+IPEndPointBasis::LeaveMulticastGroupHandler IPEndPointBasis::sLeaveMulticastGroupHandler;
+#endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #if INET_CONFIG_ENABLE_IPV4
 #define LWIP_IPV4_ADDR_T ip4_addr_t
@@ -496,6 +501,13 @@ INET_ERROR IPEndPointBasis::JoinMulticastGroup(InterfaceId aInterfaceId, const I
 #endif // INET_CONFIG_ENABLE_IPV4
 
     case kIPAddressType_IPv6: {
+#if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+        if (sJoinMulticastGroupHandler != nullptr)
+        {
+            return sJoinMulticastGroupHandler(aInterfaceId, aAddress);
+        }
+#endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #ifdef HAVE_IPV6_MULTICAST
         lRetval = LwIPIPv6JoinLeaveMulticastGroup(aInterfaceId, aAddress, mld6_joingroup_netif);
@@ -581,6 +593,13 @@ INET_ERROR IPEndPointBasis::LeaveMulticastGroup(InterfaceId aInterfaceId, const 
 #endif // INET_CONFIG_ENABLE_IPV4
 
     case kIPAddressType_IPv6: {
+#if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+        if (sLeaveMulticastGroupHandler != nullptr)
+        {
+            return sLeaveMulticastGroupHandler(aInterfaceId, aAddress);
+        }
+#endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #if LWIP_IPV6_MLD && LWIP_IPV6_ND && LWIP_IPV6
         lRetval = LwIPIPv6JoinLeaveMulticastGroup(aInterfaceId, aAddress, mld6_leavegroup_netif);

--- a/src/inet/IPEndPointBasis.h
+++ b/src/inet/IPEndPointBasis.h
@@ -166,6 +166,18 @@ protected:
     void ReleaseAll();
 #endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
+#if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+public:
+    using JoinMulticastGroupHandler  = CHIP_ERROR (*)(InterfaceId, const IPAddress &);
+    using LeaveMulticastGroupHandler = CHIP_ERROR (*)(InterfaceId, const IPAddress &);
+    static void SetJoinMulticastGroupHandler(JoinMulticastGroupHandler handler) { sJoinMulticastGroupHandler = handler; }
+    static void SetLeaveMulticastGroupHandler(LeaveMulticastGroupHandler handler) { sLeaveMulticastGroupHandler = handler; }
+
+private:
+    static JoinMulticastGroupHandler sJoinMulticastGroupHandler;
+    static LeaveMulticastGroupHandler sLeaveMulticastGroupHandler;
+#endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+
 private:
     IPEndPointBasis()                        = delete;
     IPEndPointBasis(const IPEndPointBasis &) = delete;

--- a/src/platform/Zephyr/ThreadStackManagerImpl.cpp
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.cpp
@@ -27,19 +27,38 @@
 #include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp>
 #include <platform/Zephyr/ThreadStackManagerImpl.h>
 
+#include <inet/IPEndPointBasis.h>
 #include <platform/OpenThread/OpenThreadUtils.h>
 #include <platform/ThreadStackManager.h>
+#include <support/CodeUtils.h>
 
 namespace chip {
 namespace DeviceLayer {
 
 using namespace ::chip::DeviceLayer::Internal;
+using namespace ::chip::Inet;
 
 ThreadStackManagerImpl ThreadStackManagerImpl::sInstance;
 
 CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
 {
-    return GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(openthread_get_default_instance());
+    otInstance * const instance = openthread_get_default_instance();
+
+    ReturnErrorOnFailure(GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(instance));
+
+    IPEndPointBasis::SetJoinMulticastGroupHandler([](InterfaceId, const IPAddress & address) {
+        const otIp6Address otAddress = ToOpenThreadIP6Address(address);
+        const auto otError           = otIp6SubscribeMulticastAddress(openthread_get_default_instance(), &otAddress);
+        return MapOpenThreadError(otError);
+    });
+
+    IPEndPointBasis::SetLeaveMulticastGroupHandler([](InterfaceId, const IPAddress & address) {
+        const otIp6Address otAddress = ToOpenThreadIP6Address(address);
+        const auto otError           = otIp6UnsubscribeMulticastAddress(openthread_get_default_instance(), &otAddress);
+        return MapOpenThreadError(otError);
+    });
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_StartThreadTask()

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -621,28 +621,51 @@ struct LwIPEvent;
 #ifndef CHIP_SYSTEM_CONFIG_USE_POSIX_PIPE
 #if (CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK) && !__ZEPHYR__
 #define CHIP_SYSTEM_CONFIG_USE_POSIX_PIPE 1
+#else
+#define CHIP_SYSTEM_CONFIG_USE_POSIX_PIPE 0
 #endif
 #endif // CHIP_SYSTEM_CONFIG_USE_POSIX_PIPE
 
-#ifndef CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS && __ZEPHYR__
 /**
  *  @def CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
  *
  *  @brief
  *      Include missing functions for Zephyr sockets
  *
- *  Zephyr socket API lacks some of the functions required by CHIP, e.g. getsockname, recvmsg.
+ *  Zephyr socket API lacks some of the functions required by CHIP.
  *  If this value is set CHIP will provide the missing functions.
  *
  *  Defaults to enabled on Zephyr platforms using sockets
  */
+#ifndef CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS && __ZEPHYR__
 #define CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS 1
+#else
+#define CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS 0
 #endif
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
 
-#ifndef CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
+/**
+ *  @def CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+ *
+ *  @brief
+ *      Use platform API to join and leave multicast groups.
+ *
+ *  In case a given platform does not support adding and removing multicast
+ *  addresses to a network interface using the generic network API like LWIP
+ *  or sockets, this setting allows the platform layer to inject handlers
+ *  which achieve the goal by other means.
+ *
+ *  Defaults to enabled on Zephyr platforms using sockets
+ */
+#ifndef CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && __ZEPHYR__
+#define CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API 1
+#else
+#define CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API 0
+#endif
+#endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+
 /**
  *  @def CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
  *
@@ -651,7 +674,11 @@ struct LwIPEvent;
  *
  *  Defaults to enabled on Zephyr platforms using sockets
  */
+#ifndef CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS && __ZEPHYR__
 #define CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF 1
+#else
+#define CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF 0
 #endif
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 


### PR DESCRIPTION
According to the spec, a CHIP device should join a multicast
group based on Group ID it obtained during the commissioning
process. Currently, Zephyr/nRF Connect platform does not
support adding multicast addresses to OpenThread network
interfaces using the socket API. Workaround that by
implementing an injection mechanism so that a platform may
provide a custom handlers for the multicast operations.
