### PR TITLE
[nrfconnect] Switch workflow to use build_examples.py

### DIFF
--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -67,82 +67,74 @@ jobs:
             - name: Build example nRF Connect SDK Lock App on nRF52840 DK
               timeout-minutes: 10
               run: |
-                  scripts/examples/nrfconnect_example.sh lock-app nrf52840dk_nrf52840
+                  scripts/run_in_build_env.sh "scripts/build/build_examples.py --no-log-timestamps --target nrf-nrf52840-lock build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf52840dk_nrf52840 lock-app \
-                    examples/lock-app/nrfconnect/build/nrf52840dk_nrf52840/zephyr/zephyr.elf \
+                    out/nrf-nrf52840-lock/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
             - name: Build example nRF Connect SDK Lighting App on nRF52840 DK
               timeout-minutes: 10
               run: |
-                  scripts/examples/nrfconnect_example.sh lighting-app nrf52840dk_nrf52840
+                  scripts/run_in_build_env.sh "scripts/build/build_examples.py --no-log-timestamps --target nrf-nrf52840-light build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf52840dk_nrf52840 lighting-app \
-                    examples/lighting-app/nrfconnect/build/nrf52840dk_nrf52840/zephyr/zephyr.elf \
+                    out/nrf-nrf52840-light/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
             - name: Build example nRF Connect SDK Lighting App on nRF52840 DK with RPC
               timeout-minutes: 10
               run: |
-                  scripts/examples/nrfconnect_example.sh lighting-app nrf52840dk_nrf52840 -DOVERLAY_CONFIG=rpc.overlay
+                  scripts/run_in_build_env.sh "scripts/build/build_examples.py --no-log-timestamps --target nrf-nrf52840-light-rpc build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf52840dk_nrf52840+rpc lighting-app \
-                    examples/lighting-app/nrfconnect/build/nrf52840dk_nrf52840/zephyr/zephyr.elf \
+                    out/nrf-nrf52840-light-rpc/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
             - name: Build example nRF Connect SDK Shell on nRF52840 DK
               timeout-minutes: 10
               run: |
-                  scripts/examples/nrfconnect_example.sh shell nrf52840dk_nrf52840
+                  scripts/run_in_build_env.sh "scripts/build/build_examples.py --no-log-timestamps --target nrf-nrf52840-shell build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf52840dk_nrf52840 shell \
-                    examples/shell/nrfconnect/build/nrf52840dk_nrf52840/zephyr/zephyr.elf \
+                    out/nrf-nrf52840-shell/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
             - name: Build example nRF Connect SDK Pigweed on nRF52840 DK
               timeout-minutes: 10
               run: |
-                  scripts/examples/nrfconnect_example.sh pigweed-app nrf52840dk_nrf52840
+                  scripts/run_in_build_env.sh "scripts/build/build_examples.py --no-log-timestamps --target nrf-nrf52840-pigweed build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf52840dk_nrf52840 pigweed-app \
-                    examples/pigweed-app/nrfconnect/build/nrf52840dk_nrf52840/zephyr/zephyr.elf \
+                    out/nrf-nrf52840-pigweed/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
             - name: Build example nRF Connect SDK Lock App on nRF5340 DK
               timeout-minutes: 10
               run: |
-                  scripts/examples/nrfconnect_example.sh lock-app nrf5340dk_nrf5340_cpuapp
+                  scripts/run_in_build_env.sh "scripts/build/build_examples.py --no-log-timestamps --target nrf-nrf5340-lock build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf5340dk_nrf5340_cpuapp lock-app \
-                    examples/lock-app/nrfconnect/build/nrf5340dk_nrf5340_cpuapp/zephyr/zephyr.elf \
+                    out/nrf-nrf5340-lock/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
             - name: Build example nRF Connect SDK Lighting App on nRF5340 DK
               timeout-minutes: 10
               run: |
-                  scripts/examples/nrfconnect_example.sh lighting-app nrf5340dk_nrf5340_cpuapp
+                  scripts/run_in_build_env.sh "scripts/build/build_examples.py --no-log-timestamps --target nrf-nrf5340-light build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf5340dk_nrf5340_cpuapp lighting-app \
-                    examples/lighting-app/nrfconnect/build/nrf5340dk_nrf5340_cpuapp/zephyr/zephyr.elf \
-                    /tmp/bloat_reports/
-            - name: Build example nRF Connect SDK Shell on nRF5340 DK
-              timeout-minutes: 10
-              run: |
-                  scripts/examples/nrfconnect_example.sh shell nrf5340dk_nrf5340_cpuapp
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    nrfconnect nrf5340dk_nrf5340_cpuapp shell \
-                    examples/shell/nrfconnect/build/nrf5340dk_nrf5340_cpuapp/zephyr/zephyr.elf \
+                    out/nrf-nrf5340-light/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
             - name: Build example nRF Connect SDK Pump App on nRF52840 DK
               timeout-minutes: 10
               run: |
-                  scripts/examples/nrfconnect_example.sh pump-app nrf52840dk_nrf52840
+                  scripts/run_in_build_env.sh "scripts/build/build_examples.py --no-log-timestamps --target nrf-nrf52840-pump build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf52840dk_nrf52840 pump-app \
-                    examples/pump-app/nrfconnect/build/nrf52840dk_nrf52840/zephyr/zephyr.elf \
+                    out/nrf-nrf52840-pump/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
             - name: Build example nRF Connect SDK Pump Controller App on nRF52840 DK
               timeout-minutes: 10
               run: |
-                  scripts/examples/nrfconnect_example.sh pump-controller-app nrf52840dk_nrf52840
+                  scripts/run_in_build_env.sh "scripts/build/build_examples.py --no-log-timestamps --target nrf-nrf52840-pump-controller build"
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf52840dk_nrf52840 pump-controller-app \
-                    examples/pump-controller-app/nrfconnect/build/nrf52840dk_nrf52840/zephyr/zephyr.elf \
+                    out/nrf-nrf52840-pump-controller/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
             - name: Run unit tests for Zephyr native_posix_64 platform
               timeout-minutes: 10

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -122,19 +122,6 @@
             "problemMatcher": []
         },
         {
-            "label": "Build nRF Connect Pigweed Example (nRF52840)",
-            "type": "shell",
-            "command": "source scripts/activate.sh && scripts/examples/nrfconnect_example.sh pigweed-app nrf52840dk_nrf52840",
-            "group": "build",
-            "problemMatcher": {
-                "base": "$gcc",
-                "fileLocation": [
-                    "relative",
-                    "${workspaceFolder}/examples/pigweed-app/nrfconnect/build/nrf52840dk_nrf52840"
-                ]
-            }
-        },
-        {
             "label": "Run Mbed Application",
             "type": "shell",
             "command": "scripts/examples/mbed_example.sh",
@@ -325,6 +312,7 @@
                 "nrf-nrf52840-light",
                 "nrf-nrf52840-light-rpc",
                 "nrf-nrf52840-lock",
+                "nrf-nrf52840-pigweed",
                 "nrf-nrf52840-pump",
                 "nrf-nrf52840-pump-controller",
                 "nrf-nrf52840-shell",

--- a/scripts/build/build/__init__.py
+++ b/scripts/build/build/__init__.py
@@ -27,13 +27,13 @@ class Context:
         self.output_prefix = output_prefix
         self.completed_steps = set()
 
-    def SetupBuilders(self, targets: Sequence[Target], enable_flashbundle: bool):
+    def SetupBuilders(self, targets: Sequence[Target], enable_flashbundle: bool, custom_build_arg: Sequence[str]):
         """Configures internal builders for the given platform/board/app combination. """
 
         self.builders = []
         for target in targets:
             self.builders.append(target.Create(
-                self.runner, self.repository_path, self.output_prefix, enable_flashbundle))
+                self.runner, self.repository_path, self.output_prefix, enable_flashbundle, custom_build_arg))
 
         # whenever builders change, assume generation is required again
         self.completed_steps.discard(BuildSteps.GENERATED)

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -14,7 +14,7 @@
 
 import os
 
-from typing import Any, List
+from typing import Any, List, Sequence
 from itertools import combinations
 
 from builders.android import AndroidBoard, AndroidApp, AndroidBuilder
@@ -66,7 +66,7 @@ class Target:
         clone.create_kw_args.update(kargs)
         return clone
 
-    def Create(self, runner, repository_path: str, output_prefix: str, enable_flashbundle: bool):
+    def Create(self, runner, repository_path: str, output_prefix: str, enable_flashbundle: bool, custom_build_arg: Sequence[str]):
         builder = self.builder_class(
             repository_path, runner=runner, **self.create_kw_args)
 
@@ -74,6 +74,7 @@ class Target:
         builder.identifier = self.name
         builder.output_dir = os.path.join(output_prefix, self.name)
         builder.enable_flashbundle(enable_flashbundle)
+        builder.custom_build_arg = custom_build_arg
 
         return builder
 
@@ -272,6 +273,8 @@ def NrfTargets():
 
         yield rpc
 
+        if '-nrf52840' in rpc.name:
+            yield target.Extend('pigweed', app=NrfApp.PIGWEED)
 
 def AndroidTargets():
     target = Target('android', AndroidBuilder)

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -276,6 +276,7 @@ def NrfTargets():
         if '-nrf52840' in rpc.name:
             yield target.Extend('pigweed', app=NrfApp.PIGWEED)
 
+
 def AndroidTargets():
     target = Target('android', AndroidBuilder)
 

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -116,9 +116,14 @@ def ValidateRepoPath(context, parameter, value):
     default=False,
     is_flag=True,
     help='Skip timestaps in log output')
+@click.option(
+    '--custom-build-arg',
+    multiple=True,
+    default=[],
+    help='Target-specific build argument')
 @click.pass_context
 def main(context, log_level, target, target_glob, skip_target_glob, repo, out_prefix, clean,
-         dry_run, dry_run_output, enable_flashbundle, no_log_timestamps):
+         dry_run, dry_run_output, enable_flashbundle, no_log_timestamps, custom_build_arg):
     # Ensures somewhat pretty logging of what is going on
     log_fmt = '%(asctime)s %(levelname)-7s %(message)s'
     if no_log_timestamps:
@@ -169,7 +174,7 @@ before running this script.
     context.obj = build.Context(
         repository_path=repo, output_prefix=out_prefix, runner=runner)
     context.obj.SetupBuilders(
-        targets=targets, enable_flashbundle=enable_flashbundle)
+        targets=targets, enable_flashbundle=enable_flashbundle, custom_build_arg=custom_build_arg)
 
     if clean:
         context.obj.CleanOutputDirectories()

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -90,6 +90,7 @@ mbed-CY8CPROTO_062_4343W-shell-release
 nrf-nrf52840-light
 nrf-nrf52840-light-rpc
 nrf-nrf52840-lock
+nrf-nrf52840-pigweed
 nrf-nrf52840-pump
 nrf-nrf52840-pump-controller
 nrf-nrf52840-shell

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -521,6 +521,11 @@ bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf52840-lock -b nrf52840dk_nrf52840 {root}/examples/lock-app/nrfconnect'
 
+# Generating nrf-nrf52840-pigweed
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf52840-pigweed -b nrf52840dk_nrf52840 {root}/examples/pigweed-app/nrfconnect'
+
 # Generating nrf-nrf52840-pump
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
@@ -1073,6 +1078,9 @@ ninja -C {out}/nrf-nrf52840-light-rpc
 
 # Building nrf-nrf52840-lock
 ninja -C {out}/nrf-nrf52840-lock
+
+# Building nrf-nrf52840-pigweed
+ninja -C {out}/nrf-nrf52840-pigweed
 
 # Building nrf-nrf52840-pump
 ninja -C {out}/nrf-nrf52840-pump

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -38,6 +38,7 @@ mbed-CY8CPROTO_062_4343W-shell-release
 nrf-nrf52840-light
 nrf-nrf52840-light-rpc
 nrf-nrf52840-lock
+nrf-nrf52840-pigweed
 nrf-nrf52840-pump
 nrf-nrf52840-pump-controller
 nrf-nrf52840-shell


### PR DESCRIPTION
1. Use the common build script in nrfconnect workflow.
2. Add nRF52840 pigweed-app to build_examples.py
3. Add --custom-build-arg flag to build_examples.py to support
   target-specific build options.

#### Problem
What is being fixed?  Examples:
* Fix crash on startup
* Fixes #12345 Frobnozzle is leaky (exactly like that, so GitHub will auto-close the issue).

#### Change overview
What's in this PR

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how?
* If no testing is required, why not?
