### PR TITLE
[zephyr] BootReasons and NetworkInterfaces fixes

### DIFF
--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.h
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.h
@@ -49,6 +49,11 @@ public:
     CHIP_ERROR GetBootReason(uint8_t & bootReason) override;
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
+
+private:
+    DiagnosticDataProviderImpl();
+
+    const uint8_t mBootReason;
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
1. Fix BootReasons attribute of GeneralDiagnostics cluster:
 - Make sure hwinfo_get_reset_cause() is called once per boot and is immediately followed by hwinfo_clear_reset_cause() since the reset cause is accumulated between subsequent resets.
 - Add support for SoftwareUpdateCompleted boot reason.
 - Reduce the scope of reasons classified as SoftwareReset.

2. Add a missing bound check to the NetworkInterfaces attribute provider and always assume that Zephyr's net_if API is available.